### PR TITLE
Join on stderr stream in SSH Exec

### DIFF
--- a/deploy-runner-agent/src/main/java/jetbrains/buildServer/deployer/agent/ssh/SSHExecProcessAdapter.java
+++ b/deploy-runner-agent/src/main/java/jetbrains/buildServer/deployer/agent/ssh/SSHExecProcessAdapter.java
@@ -117,7 +117,7 @@ class SSHExecProcessAdapter extends SyncBuildProcessAdapter {
       errGobbler.notifyProcessExit();
       try {
         outputGobbler.join();
-        outputGobbler.join();
+        errGobbler.join();
       } catch (InterruptedException e) {
         LOG.warnAndDebugDetails("SSH command interrupted", e);
       }


### PR DESCRIPTION
We are seeing issues with SSH exec where additional output is written to the build log after the SSH exec step says it is done.

>SSH exit-code 1
Disconnecting from (AGENT) port 22
Caught an exception, leaving main loop due to Socket closed
Step Execute on (AGENT) (SSH Exec) failed
...
(((More output is still written to the build log here)))

If SSH exec is the last build step, and a service message to publish artifacts is part of the later output then TC will end the build but still be publishing the artifacts. The next build to run on the agent will immediately fail with "_Failed to start build. Build with id null is running on agent_"

I'm not sure if this change will fix my issue, but it looks like a bug and it could cause this behavior.